### PR TITLE
Fix render.yaml build command syntax

### DIFF
--- a/apps/mobile/render.yaml
+++ b/apps/mobile/render.yaml
@@ -4,7 +4,7 @@ services:
     runtime: node
     region: oregon
     plan: starter # Change to 'standard' for production
-    buildCommand: cd apps/mobile && npm ci && npm run build:web
+    buildCommand: cd apps/mobile; npm ci; npm run build:web
     staticPublishPath: ./apps/mobile/dist
     pullRequestPreviewsEnabled: true
     envVars:


### PR DESCRIPTION
## Summary
- Fix build command syntax in mobile app render.yaml to use semicolons
- Align with admin app configuration for consistency

## Key Changes

### Build Command Syntax Fix
- 🔧 Change from `&&` to `;` separators in buildCommand
- 📋 Match syntax pattern used in admin app render.yaml
- ✅ Ensure reliable command execution in Render.com environment

### Command Details
- **Before**: `cd apps/mobile && npm ci && npm run build:web`
- **After**: `cd apps/mobile; npm ci; npm run build:web`

### Functionality Preserved
- ✅ Same build process and output
- ✅ All environment variables remain unchanged
- ✅ Static site deployment configuration intact

## Test plan
- [ ] Verify render.yaml syntax is valid
- [ ] Test build command executes properly in Render.com
- [ ] Confirm web app deploys successfully
- [ ] Validate all environment variables work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)