### PR TITLE
🚨 CRITICAL: Fix workspace dependencies in shared packages for Render.com

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -19,9 +19,9 @@
     "check-migrations": "tsx scripts/sync-types-from-migrations.ts && git diff --quiet types/coachmeld.ts || echo '⚠️  Types have changed - please commit the updates'"
   },
   "dependencies": {
-    "@coachmeld/shared-types": "workspace:*",
-    "@coachmeld/shared-config": "workspace:*",
-    "@coachmeld/shared-utils": "workspace:*",
+    "@coachmeld/shared-types": "file:../../packages/shared-types",
+    "@coachmeld/shared-config": "file:../../packages/shared-config",
+    "@coachmeld/shared-utils": "file:../../packages/shared-utils",
     "@google/generative-ai": "^0.24.1",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/apps/admin/render.yaml
+++ b/apps/admin/render.yaml
@@ -5,7 +5,7 @@ services:
     region: oregon # Change to your preferred region
     plan: starter # Change to 'standard' for production
     rootDir: apps/admin
-    buildCommand: cd ../.. && npm install && cd apps/admin && npm run build
+    buildCommand: cd ../.. && npm install && npm run build:packages && cd apps/admin && npm run build
     startCommand: npm run start
     healthCheckPath: /api/health
     envVars:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:admin": "cd apps/admin && bun run build",
     "build:web": "cd apps/mobile && bun expo export -p web",
     "build:mobile": "cd apps/mobile && bun expo build",
+    "build:packages": "cd packages/shared-types && npm run build && cd ../shared-config && npm run build && cd ../shared-utils && npm run build",
     "install:all": "bun install",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules",
     "type-check": "bun run type-check:mobile && bun run type-check:admin",

--- a/packages/shared-config/package.json
+++ b/packages/shared-config/package.json
@@ -16,6 +16,6 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@coachmeld/shared-types": "workspace:*"
+    "@coachmeld/shared-types": "file:../shared-types"
   }
 }

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -16,6 +16,6 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@coachmeld/shared-types": "workspace:*"
+    "@coachmeld/shared-types": "file:../shared-types"
   }
 }


### PR DESCRIPTION
## 🚨 CRITICAL DEPLOYMENT FIX

**Resolves the workspace dependency error that's still blocking Render.com deployment**

## Root Cause Found
The shared packages themselves still had `workspace:*` dependencies:
- `packages/shared-utils/package.json`
- `packages/shared-config/package.json`

## Fix Applied
- **shared-utils**: `workspace:*` → `file:../shared-types`
- **shared-config**: `workspace:*` → `file:../shared-types`

## Error Resolved
`npm ERR\! Unsupported URL Type "workspace:": workspace:*`

## Impact
✅ All workspace dependencies now use `file:` protocol  
✅ Compatible with standard npm in production environments  
✅ Should resolve Render.com deployment failure  

**⚠️ MERGE IMMEDIATELY** - This is blocking production deployment